### PR TITLE
Fix wrong icon name

### DIFF
--- a/icons.html
+++ b/icons.html
@@ -1785,7 +1785,7 @@
 								<polygon id="Rectangle-161" points="4 4 16 10 4 16"></polygon>
 							</g>
 						</g>
-						</svg>play-outline</span>
+						</svg>play</span>
 					</div>
 					
 					<div class="icon-container col-xs-12 col-sm-4">


### PR DESCRIPTION
On the icons.html page there are currently 2 `play-outline` icons, but only 1 is actually the `play-outline` icon.